### PR TITLE
feat(orders): adicionando listagem de orders

### DIFF
--- a/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/OrderAPI.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/OrderAPI.java
@@ -8,12 +8,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import soat.project.fastfoodsoat.adapter.inbound.api.model.DefaultApiError;
 import soat.project.fastfoodsoat.adapter.inbound.api.model.request.CreateOrderRequest;
 import soat.project.fastfoodsoat.adapter.inbound.api.model.response.CreateOrderResponse;
+import soat.project.fastfoodsoat.adapter.inbound.api.model.response.ListOrderResponse;
+import soat.project.fastfoodsoat.application.usecase.order.retrieve.list.ListOrderOutput;
+import soat.project.fastfoodsoat.domain.pagination.Pagination;
 
 @Tag(name = "Order")
 @RequestMapping("/orders")
@@ -51,4 +52,32 @@ public interface OrderAPI {
         }
     )
     ResponseEntity<CreateOrderResponse> create(@RequestBody CreateOrderRequest orderRequest);
+
+    @GetMapping(
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(
+            summary = "List orders"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Orders listed successfully"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "An internal server error was thrown",
+                            content = @Content(schema = @Schema(implementation = DefaultApiError.class))
+                    )
+            }
+    )
+    ResponseEntity<Pagination<ListOrderResponse>> list(
+            @RequestParam(name = "search", required = false, defaultValue = "") final String search,
+            @RequestParam(name = "page", required = false, defaultValue = "0") final int page,
+            @RequestParam(name = "perPage", required = false, defaultValue = "10") final int perPage,
+            @RequestParam(name = "sort", required = false, defaultValue = "orderNumber") final String sort,
+            @RequestParam(name = "dir", required = false, defaultValue = "asc") final String direction
+    );
+
 }

--- a/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/controller/OrderController.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/controller/OrderController.java
@@ -6,19 +6,29 @@ import org.springframework.web.bind.annotation.RestController;
 import soat.project.fastfoodsoat.adapter.inbound.api.OrderAPI;
 import soat.project.fastfoodsoat.adapter.inbound.api.model.request.CreateOrderRequest;
 import soat.project.fastfoodsoat.adapter.inbound.api.model.response.CreateOrderResponse;
+import soat.project.fastfoodsoat.adapter.inbound.api.model.response.ListOrderResponse;
 import soat.project.fastfoodsoat.adapter.inbound.api.presenter.OrderPresenter;
 import soat.project.fastfoodsoat.application.usecase.order.create.CreateOrderCommand;
 import soat.project.fastfoodsoat.application.usecase.order.create.CreateOrderOutput;
 import soat.project.fastfoodsoat.application.usecase.order.create.CreateOrderProductCommand;
 import soat.project.fastfoodsoat.application.usecase.order.create.CreateOrderUseCase;
+import soat.project.fastfoodsoat.application.usecase.order.retrieve.list.ListOrderOutput;
+import soat.project.fastfoodsoat.application.usecase.order.retrieve.list.ListOrderUseCase;
+import soat.project.fastfoodsoat.domain.pagination.Pagination;
+import soat.project.fastfoodsoat.domain.pagination.SearchQuery;
 
 @RestController
 public class OrderController implements OrderAPI {
 
     private final CreateOrderUseCase createOrderUseCase;
+    private final ListOrderUseCase listOrderUseCase;
 
-    public OrderController(final CreateOrderUseCase createOrderUseCase) {
+    public OrderController(
+            final CreateOrderUseCase createOrderUseCase,
+            final ListOrderUseCase listOrderUseCase
+    ) {
         this.createOrderUseCase = createOrderUseCase;
+        this.listOrderUseCase = listOrderUseCase;
     }
 
     @Override
@@ -33,5 +43,20 @@ public class OrderController implements OrderAPI {
 
         final CreateOrderOutput output = this.createOrderUseCase.execute(command);
         return ResponseEntity.status(HttpStatus.CREATED).body(OrderPresenter.present(output));
+    }
+
+    @Override
+    public ResponseEntity<Pagination<ListOrderResponse>> list(
+            final String search,
+            final int page,
+            final int perPage,
+            final String sort,
+            final String direction
+    ) {
+        final var query = new SearchQuery(page, perPage, search, sort, direction);
+
+        final var output = this.listOrderUseCase.execute(query);
+
+        return ResponseEntity.ok(output.map(OrderPresenter::present));
     }
 }

--- a/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/model/response/ListOrderProductResponse.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/model/response/ListOrderProductResponse.java
@@ -1,0 +1,13 @@
+package soat.project.fastfoodsoat.adapter.inbound.api.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public record ListOrderProductResponse(
+        @JsonProperty("value") BigDecimal value,
+        @JsonProperty("quantity") Integer quantity,
+        @JsonProperty("product_id") Integer productId,
+        @JsonProperty("product_name") String productName
+) {
+}

--- a/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/model/response/ListOrderResponse.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/model/response/ListOrderResponse.java
@@ -1,0 +1,16 @@
+package soat.project.fastfoodsoat.adapter.inbound.api.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record ListOrderResponse(
+        @JsonProperty("public_id") UUID publicId,
+        @JsonProperty("value") BigDecimal value,
+        @JsonProperty("order_number") Integer orderNumber,
+        @JsonProperty("status") String status,
+        @JsonProperty("products") List<ListOrderProductResponse> products
+) {
+}

--- a/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/presenter/OrderPresenter.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/inbound/api/presenter/OrderPresenter.java
@@ -2,7 +2,16 @@ package soat.project.fastfoodsoat.adapter.inbound.api.presenter;
 
 import soat.project.fastfoodsoat.adapter.inbound.api.model.response.CreateOrderProductResponse;
 import soat.project.fastfoodsoat.adapter.inbound.api.model.response.CreateOrderResponse;
+import soat.project.fastfoodsoat.adapter.inbound.api.model.response.ListOrderProductResponse;
+import soat.project.fastfoodsoat.adapter.inbound.api.model.response.ListOrderResponse;
 import soat.project.fastfoodsoat.application.usecase.order.create.CreateOrderOutput;
+import soat.project.fastfoodsoat.application.usecase.order.retrieve.list.ListOrderOutput;
+import soat.project.fastfoodsoat.application.usecase.order.retrieve.list.ListOrderProductOutput;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.isNull;
 
 public interface OrderPresenter {
 
@@ -18,6 +27,27 @@ public interface OrderPresenter {
                         .toArray(CreateOrderProductResponse[]::new),
                 output.createdAt(),
                 output.updatedAt()
+        );
+    }
+
+    static ListOrderResponse present(final ListOrderOutput output) {
+        return new ListOrderResponse(
+                output.publicId(),
+                output.value(),
+                output.orderNumber(),
+                output.status(),
+                isNull(output.products()) ? List.of() : output.products().stream()
+                        .map(OrderPresenter::present)
+                        .toList()
+        );
+    }
+
+    static ListOrderProductResponse present(final ListOrderProductOutput output) {
+        return new ListOrderProductResponse(
+                output.value(),
+                output.quantity(),
+                output.productId(),
+                output.productName()
         );
     }
 }

--- a/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/OrderJpaGateway.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/OrderJpaGateway.java
@@ -1,5 +1,8 @@
 package soat.project.fastfoodsoat.adapter.outbound.jpa;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import soat.project.fastfoodsoat.adapter.outbound.jpa.entity.OrderJpaEntity;
 import soat.project.fastfoodsoat.adapter.outbound.jpa.entity.ProductJpaEntity;
@@ -10,12 +13,17 @@ import soat.project.fastfoodsoat.domain.exception.NotFoundException;
 import soat.project.fastfoodsoat.domain.order.Order;
 import soat.project.fastfoodsoat.domain.order.OrderGateway;
 import soat.project.fastfoodsoat.domain.order.OrderPublicId;
+import soat.project.fastfoodsoat.domain.pagination.Pagination;
+import soat.project.fastfoodsoat.domain.pagination.SearchQuery;
 import soat.project.fastfoodsoat.domain.product.Product;
 import soat.project.fastfoodsoat.domain.product.ProductId;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static java.util.Objects.isNull;
 
 @Component
 public class OrderJpaGateway implements OrderGateway {
@@ -48,6 +56,66 @@ public class OrderJpaGateway implements OrderGateway {
     public Integer findLastOrderNumber() {
         return this.orderRepository.findMaxOrderNumber()
                 .orElse(0);
+    }
+
+    @Override
+    public Pagination<Order> findAll(final SearchQuery query) {
+        final var page = PageRequest.of(
+                query.page(),
+                query.perPage(),
+                Sort.Direction.fromString(query.direction()),
+                query.sort()
+        );
+
+        if (isNull(query.terms())) {
+            final var pageResult = this.orderRepository.findAll(page);
+            return new Pagination<>(
+                    pageResult.getNumber(),
+                    pageResult.getSize(),
+                    pageResult.getTotalElements(),
+                    pageResult.map(OrderJpaMapper::fromJpa).toList()
+            );
+        }
+
+        final var terms = query.terms();
+        var pageResult = tryFindByPublicId(terms, page);
+
+        if (pageResult.isEmpty()) {
+            pageResult = tryFindByOrderNumber(terms, page);
+        }
+
+        if (pageResult.isEmpty()) {
+            pageResult = tryFindByProductName(terms, page);
+        }
+
+        return new Pagination<>(
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.map(OrderJpaMapper::fromJpa).toList()
+        );
+    }
+
+    private Page<OrderJpaEntity> tryFindByPublicId(final String terms, final PageRequest page) {
+        try {
+            final UUID uuid = UUID.fromString(terms);
+            return orderRepository.findByPublicId(uuid, page);
+        } catch (IllegalArgumentException e) {
+            return org.springframework.data.domain.Page.empty(page);
+        }
+    }
+
+    private Page<OrderJpaEntity> tryFindByOrderNumber(final String terms, final PageRequest page) {
+        try {
+            final Integer orderNumber = Integer.valueOf(terms);
+            return orderRepository.findByOrderNumber(orderNumber, page);
+        } catch (NumberFormatException e) {
+            return org.springframework.data.domain.Page.empty(page);
+        }
+    }
+
+    private Page<OrderJpaEntity> tryFindByProductName(final String terms, final PageRequest page) {
+        return orderRepository.findDistinctByOrderProductsProductNameContainingIgnoreCase(terms, page);
     }
 
     private Map<Integer, ProductJpaEntity> createMapOfProductsById(final Order order) {

--- a/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/entity/ClientJpaEntity.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/entity/ClientJpaEntity.java
@@ -37,7 +37,7 @@ public class ClientJpaEntity {
     private Instant createdAt;
 
     @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "update_at")
+    @Column(name = "updated_at")
     private Instant updateAt;
 
     @Column(name = "deleted_at")

--- a/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/entity/OrderJpaEntity.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/entity/OrderJpaEntity.java
@@ -31,7 +31,7 @@ public class OrderJpaEntity {
     @ColumnTransformer(write="?::order_status")
     private String status;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
     private List<OrderProductJpaEntity> orderProducts;
 
     @ColumnDefault("CURRENT_TIMESTAMP")

--- a/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/entity/OrderProductJpaEntity.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/entity/OrderProductJpaEntity.java
@@ -106,6 +106,10 @@ public class OrderProductJpaEntity {
         return product;
     }
 
+    public void setProduct(ProductJpaEntity product) {
+        this.product = product;
+    }
+
     public void setOrder(OrderJpaEntity orderJpaEntity) {
         this.order = orderJpaEntity;
     }

--- a/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/repository/OrderRepository.java
+++ b/src/main/java/soat/project/fastfoodsoat/adapter/outbound/jpa/repository/OrderRepository.java
@@ -1,5 +1,7 @@
 package soat.project.fastfoodsoat.adapter.outbound.jpa.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import soat.project.fastfoodsoat.adapter.outbound.jpa.entity.OrderJpaEntity;
@@ -14,4 +16,10 @@ public interface OrderRepository extends JpaRepository<OrderJpaEntity, Integer> 
 
     @Query("SELECT o FROM OrderJpaEntity o WHERE o.publicId = :publicId AND o.deletedAt IS NULL")
     Optional<OrderJpaEntity> findOneByPublicId(UUID publicId);
+
+    Page<OrderJpaEntity> findByPublicId(UUID publicId, Pageable pageable);
+    Page<OrderJpaEntity> findByOrderNumber(Integer orderNumber, Pageable pageable);
+    Page<OrderJpaEntity> findByStatus(String status, Pageable pageable);
+    Page<OrderJpaEntity> findDistinctByOrderProductsProductNameContainingIgnoreCase(String productName, Pageable pageable);
+
 }

--- a/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/DefaultListOrderUseCase.java
+++ b/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/DefaultListOrderUseCase.java
@@ -1,0 +1,23 @@
+package soat.project.fastfoodsoat.application.usecase.order.retrieve.list;
+
+import org.springframework.stereotype.Component;
+import soat.project.fastfoodsoat.domain.order.OrderGateway;
+import soat.project.fastfoodsoat.domain.pagination.Pagination;
+import soat.project.fastfoodsoat.domain.pagination.SearchQuery;
+
+@Component
+public class DefaultListOrderUseCase extends ListOrderUseCase {
+
+    private final OrderGateway orderGateway;
+
+    public DefaultListOrderUseCase(final OrderGateway orderGateway) {
+        this.orderGateway = orderGateway;
+    }
+
+    @Override
+    public Pagination<ListOrderOutput> execute(final SearchQuery query) {
+        return orderGateway.findAll(query)
+                .map(ListOrderOutput::from);
+    }
+
+}

--- a/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/ListOrderOutput.java
+++ b/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/ListOrderOutput.java
@@ -1,0 +1,27 @@
+package soat.project.fastfoodsoat.application.usecase.order.retrieve.list;
+
+import soat.project.fastfoodsoat.domain.order.Order;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Objects.isNull;
+
+public record ListOrderOutput(
+        UUID publicId,
+        BigDecimal value,
+        Integer orderNumber,
+        String status,
+        List<ListOrderProductOutput> products
+) {
+    public static ListOrderOutput from(final Order order) {
+        return new ListOrderOutput(
+                isNull(order.getPublicId()) ? null : order.getPublicId().getValue(),
+                order.getValue(),
+                order.getOrderNumber(),
+                order.getStatus().name(),
+                order.getOrderProducts().stream().map(ListOrderProductOutput::from).toList()
+        );
+    }
+}

--- a/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/ListOrderProductOutput.java
+++ b/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/ListOrderProductOutput.java
@@ -1,0 +1,24 @@
+package soat.project.fastfoodsoat.application.usecase.order.retrieve.list;
+
+import soat.project.fastfoodsoat.domain.order.orderproduct.OrderProduct;
+
+import java.math.BigDecimal;
+
+import static java.util.Objects.isNull;
+
+public record ListOrderProductOutput(
+        BigDecimal value,
+        Integer quantity,
+        Integer productId,
+        String productName
+) {
+    public static ListOrderProductOutput from(final OrderProduct orderProduct) {
+        return new ListOrderProductOutput(
+                orderProduct.getValue(),
+                orderProduct.getQuantity(),
+                isNull(orderProduct.getProduct()) ? null : orderProduct.getProduct().getId().getValue(),
+                isNull(orderProduct.getProduct()) ? null : orderProduct.getProduct().getName()
+        );
+    }
+
+}

--- a/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/ListOrderUseCase.java
+++ b/src/main/java/soat/project/fastfoodsoat/application/usecase/order/retrieve/list/ListOrderUseCase.java
@@ -1,0 +1,8 @@
+package soat.project.fastfoodsoat.application.usecase.order.retrieve.list;
+
+import soat.project.fastfoodsoat.application.UseCase;
+import soat.project.fastfoodsoat.domain.pagination.Pagination;
+import soat.project.fastfoodsoat.domain.pagination.SearchQuery;
+
+public abstract class ListOrderUseCase extends UseCase<SearchQuery, Pagination<ListOrderOutput>> {
+}

--- a/src/main/java/soat/project/fastfoodsoat/domain/order/OrderGateway.java
+++ b/src/main/java/soat/project/fastfoodsoat/domain/order/OrderGateway.java
@@ -1,7 +1,11 @@
 package soat.project.fastfoodsoat.domain.order;
 
+import soat.project.fastfoodsoat.domain.pagination.Pagination;
+import soat.project.fastfoodsoat.domain.pagination.SearchQuery;
+
 public interface OrderGateway {
     Order create(Order order);
     Order findByPublicId(OrderPublicId orderPublicId);
     Integer findLastOrderNumber();
+    Pagination<Order> findAll(SearchQuery query);
 }

--- a/src/test/java/soat/project/fastfoodsoat/application/usecase/order/ListOrderUseCaseTest.java
+++ b/src/test/java/soat/project/fastfoodsoat/application/usecase/order/ListOrderUseCaseTest.java
@@ -1,0 +1,211 @@
+package soat.project.fastfoodsoat.application.usecase.order;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import soat.project.fastfoodsoat.application.usecase.UseCaseTest;
+import soat.project.fastfoodsoat.application.usecase.order.retrieve.list.DefaultListOrderUseCase;
+import soat.project.fastfoodsoat.application.usecase.order.retrieve.list.ListOrderOutput;
+import soat.project.fastfoodsoat.domain.order.Order;
+import soat.project.fastfoodsoat.domain.order.OrderGateway;
+import soat.project.fastfoodsoat.domain.order.OrderPublicId;
+import soat.project.fastfoodsoat.domain.order.OrderStatus;
+import soat.project.fastfoodsoat.domain.order.orderproduct.OrderProduct;
+import soat.project.fastfoodsoat.domain.pagination.Pagination;
+import soat.project.fastfoodsoat.domain.pagination.SearchQuery;
+import soat.project.fastfoodsoat.domain.product.Product;
+import soat.project.fastfoodsoat.domain.product.ProductId;
+import soat.project.fastfoodsoat.domain.product.productCategory.ProductCategoryId;
+import soat.project.fastfoodsoat.utils.InstantUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class ListOrderUseCaseTest extends UseCaseTest {
+
+    @InjectMocks
+    private DefaultListOrderUseCase useCase;
+
+    @Mock
+    private OrderGateway orderGateway;
+
+
+    @Override
+    protected List<Object> getMocks() {
+        return List.of(orderGateway);
+    }
+
+    @Test
+    void givenValidQuery_whenCallsListOrders_shouldReturnOrders() {
+        // Given
+        final var product1 = Product.with(
+                ProductId.of(1),
+                "X-Tudo",
+                "Completo",
+                BigDecimal.valueOf(34.99),
+                "url",
+                ProductCategoryId.of(1),
+                InstantUtils.now(),
+                InstantUtils.now(),
+                null
+        );
+
+        final var product2 = Product.with(
+                ProductId.of(2),
+                "X-Salada",
+                "Leve",
+                BigDecimal.valueOf(29.99),
+                "url",
+                ProductCategoryId.of(1),
+                InstantUtils.now(),
+                InstantUtils.now(),
+                null
+        );
+
+        final var orderProduct1 = OrderProduct.newOrderProduct(
+                product1.getValue(),
+                1,
+                product1
+        );
+
+        final var orderProduct2 = OrderProduct.newOrderProduct(
+                product2.getValue().multiply(BigDecimal.valueOf(2)),
+                2,
+                product2
+        );
+
+        final var order = Order.newOrder(
+                OrderPublicId.of(UUID.randomUUID()),
+                1,
+                OrderStatus.RECEIVED,
+                orderProduct1.getValue().add(orderProduct2.getValue()),
+                List.of(orderProduct1, orderProduct2)
+        );
+
+        final var orders = List.of(order);
+
+        final var expectedPage = 0;
+        final var expectedPerPage = 10;
+        final var expectedTerms = "";
+        final var expectedSort = "createdAt";
+        final var expectedDirection = "asc";
+        final var expectedTotal = orders.size();
+
+        final var query = new SearchQuery(
+                expectedPage,
+                expectedPerPage,
+                expectedTerms,
+                expectedSort,
+                expectedDirection
+        );
+
+        final var expectedPagination = new Pagination<>(
+                expectedPage,
+                expectedPerPage,
+                expectedTotal,
+                orders
+        );
+
+        final var expectedItems = orders.stream()
+                .map(ListOrderOutput::from)
+                .toList();
+
+        when(orderGateway.findAll(any())).thenReturn(expectedPagination);
+
+        // When
+        final var actualOutput = useCase.execute(query);
+
+        // Then
+
+        assertEquals(expectedPage, actualOutput.currentPage());
+        assertEquals(expectedPerPage, actualOutput.perPage());
+        assertEquals(expectedTotal, actualOutput.total());
+        assertEquals(expectedItems, actualOutput.items());
+
+        verify(orderGateway, times(1)).findAll(any());
+    }
+
+    @Test
+    void givenValidQuery_whenCallsListOrdersAndIsEmpty_shouldReturnEmpty() {
+        // Given
+        final var orders = List.<Order>of();
+
+        final var expectedPage = 0;
+        final var expectedPerPage = 10;
+        final var expectedTerms = "";
+        final var expectedSort = "createdAt";
+        final var expectedDirection = "asc";
+        final var expectedTotal = 0;
+
+        final var query = new SearchQuery(
+                expectedPage,
+                expectedPerPage,
+                expectedTerms,
+                expectedSort,
+                expectedDirection
+        );
+
+        final var expectedPagination = new Pagination<>(
+                expectedPage,
+                expectedPerPage,
+                expectedTotal,
+                orders
+        );
+
+        when(orderGateway.findAll(any())).thenReturn(expectedPagination);
+
+        // When
+        final var actualOutput = useCase.execute(query);
+
+        // Then
+        assertEquals(expectedPage, actualOutput.currentPage());
+        assertEquals(expectedPerPage, actualOutput.perPage());
+        assertEquals(expectedTotal, actualOutput.total());
+        assertEquals(List.<ListOrderOutput>of(), actualOutput.items());
+
+        verify(orderGateway, times(1)).findAll(any());
+    }
+
+    @Test
+    void givenValidQuery_whenCallsListOrdersAndGatewayThrowsAnException_shouldReturnError() {
+        // Given
+        final var expectedPage = -1;
+        final var expectedPerPage = 0;
+        final var expectedTerms = "";
+        final var expectedSort = "createdAt";
+        final var expectedDirection = "asc";
+
+        final var query = new SearchQuery(
+                expectedPage,
+                expectedPerPage,
+                expectedTerms,
+                expectedSort,
+                expectedDirection
+        );
+
+        final var expectedErrorMessage = "Gateway error";
+
+        when(orderGateway.findAll(any()))
+                .thenThrow(new IllegalStateException(expectedErrorMessage));
+
+        // When
+        final var actualException = assertThrows(
+                IllegalStateException.class,
+                () -> useCase.execute(query)
+        );
+
+        // Then
+        Assertions.assertEquals(expectedErrorMessage, actualException.getMessage());
+
+        verify(orderGateway, times(1)).findAll(any());
+    }
+
+
+}

--- a/src/test/java/soat/project/fastfoodsoat/domain/order/OrderTest.java
+++ b/src/test/java/soat/project/fastfoodsoat/domain/order/OrderTest.java
@@ -30,7 +30,7 @@ class OrderTest {
         final var orderNumber = 1;
         final var status = OrderStatus.RECEIVED;
 
-        final var order = Order.newOrder(publicId, orderNumber, status, null, orderProduct, null);
+        final var order = Order.newOrder(publicId, orderNumber, status, null, orderProduct);
 
 
         assertNotNull(order);
@@ -53,7 +53,7 @@ class OrderTest {
         final var status = OrderStatus.RECEIVED;
         final var publicId = OrderPublicId.of(UUID.randomUUID());
 
-        final var order = Order.newOrder(publicId, orderNumber, status, value, null, null);
+        final var order = Order.newOrder(publicId, orderNumber, status, value, null);
 
 
         assertNotNull(order);
@@ -74,7 +74,7 @@ class OrderTest {
         final var publicId = OrderPublicId.of(UUID.randomUUID());
 
         final var exception = assertThrows(NotificationException.class,
-                () -> Order.newOrder(publicId, orderNumber, status, null,null, null));
+                () -> Order.newOrder(publicId, orderNumber, status, null,null));
 
         assertEquals(1, exception.getErrors().size());
         assertEquals("'value' should not be null", exception.getErrors().get(0).message());
@@ -87,7 +87,7 @@ class OrderTest {
         final var publicId = OrderPublicId.of(UUID.randomUUID());
 
         final var exception = assertThrows(NotificationException.class,
-                () -> Order.newOrder(publicId, orderNumber, status, BigDecimal.ZERO,null, null));
+                () -> Order.newOrder(publicId, orderNumber, status, BigDecimal.ZERO,null));
 
         assertEquals(1, exception.getErrors().size());
         assertEquals("'value' should be greater than zero", exception.getErrors().get(0).message());
@@ -109,7 +109,7 @@ class OrderTest {
         final var status = OrderStatus.RECEIVED;
 
         final var exception = assertThrows(NotificationException.class,
-                () -> Order.newOrder(publicId, null, status, null, orderProduct, null));
+                () -> Order.newOrder(publicId, null, status, null, orderProduct));
 
         assertEquals(1, exception.getErrors().size());
         assertEquals("'orderNumber' should not be null", exception.getErrors().get(0).message());
@@ -132,7 +132,7 @@ class OrderTest {
         final var orderNumber = 0;
 
         final var exception = assertThrows(NotificationException.class,
-                () -> Order.newOrder(publicId, orderNumber, status, null, orderProduct, null));
+                () -> Order.newOrder(publicId, orderNumber, status, null, orderProduct));
 
         assertEquals(1, exception.getErrors().size());
         assertEquals("'orderNumber' should be greater than zero", exception.getErrors().get(0).message());
@@ -154,7 +154,7 @@ class OrderTest {
         final var orderNumber = 1;
 
         final var exception = assertThrows(NotificationException.class,
-                () -> Order.newOrder(publicId, orderNumber, null, null, orderProduct, null));
+                () -> Order.newOrder(publicId, orderNumber, null, null, orderProduct));
 
         assertEquals(1, exception.getErrors().size());
         assertEquals("'status' should not be null", exception.getErrors().get(0).message());


### PR DESCRIPTION
# Pull Request: Implementação da Listagem de Pedidos

## Funcionalidades Adicionadas

- **Listagem de Pedidos**: Endpoint GET para listar todos os pedidos com suporte a:
  - Paginação
  - Filtros de busca
  - Ordenação customizável
  - Controle de quantidade de itens por página

## Detalhes Técnicos

- Adicionado endpoint `GET /orders` na API REST
- Implementação da interface `OrderAPI` com método de listagem
- Suporte para os seguintes parâmetros de consulta:
  - `search`: Termo de busca (opcional)
  - `page`: Número da página (padrão: 0)
  - `perPage`: Quantidade de itens por página (padrão: 10)
  - `sort`: Campo para ordenação (padrão: orderNumber)
  - `dir`: Direção da ordenação (asc/desc, padrão: asc)
- Resposta paginada contendo os pedidos formatados no tipo `ListOrderResponse`